### PR TITLE
Fix a small silly mistake

### DIFF
--- a/cc/ccom/scan.l
+++ b/cc/ccom/scan.l
@@ -201,7 +201,8 @@ extern void yyset_lineno (int);
 
 %%
 
-int lineno, issyshdr;
+extern int lineno;
+int issyshdr;
 
 int
 yywrap(void)

--- a/cc/cxxcom/scan.l
+++ b/cc/cxxcom/scan.l
@@ -223,7 +223,8 @@ L?\"(\\.|[^\\"])*\"	{ yylval.strp = yytext; return C_STRING; }
 
 %%
 
-int lineno, issyshdr;
+extern int lineno;
+int issyshdr;
 char *ftitle = "<stdin>";
 
 static int


### PR DESCRIPTION
I hope that it doesn't break the code. lineno has references in mip/common.c and I extern'ed it from cc/ccom/scan.l and cc/cxxcom/scan.l